### PR TITLE
Disable package installation for all containers by default

### DIFF
--- a/embedded-aerospike/src/test/java/com/playtika/test/aerospike/BaseAerospikeTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/test/aerospike/BaseAerospikeTest.java
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = BaseAerospikeTest.TestConfiguration.class)
+@SpringBootTest(
+        classes = BaseAerospikeTest.TestConfiguration.class,
+        properties = "embedded.aerospike.install.enabled=true"
+)
 public abstract class BaseAerospikeTest {
 
     protected static final String SET = "values";

--- a/embedded-aerospike/src/test/java/com/playtika/test/aerospike/DisableAerospikeTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/test/aerospike/DisableAerospikeTest.java
@@ -26,19 +26,35 @@ package com.playtika.test.aerospike;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = DisableAerospikeTest.TestConfiguration.class,
-        properties = "embedded.aerospike.enabled=false")
+@SpringBootTest(
+        classes = DisableAerospikeTest.TestConfiguration.class,
+        properties = "embedded.aerospike.enabled=false"
+)
 public class DisableAerospikeTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("aerospikeClientDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-aerospike/src/test/java/com/playtika/test/aerospike/EmbeddedAerospikeBootstrapConfigurationTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/test/aerospike/EmbeddedAerospikeBootstrapConfigurationTest.java
@@ -63,11 +63,11 @@ public class EmbeddedAerospikeBootstrapConfigurationTest extends BaseAerospikeTe
 
     @Test
     public void shouldAddLatency() throws Exception {
-        aerospikeTestOperations.addNetworkLatencyForResponses(ofMillis(1500));
+        aerospikeTestOperations.addNetworkLatencyForResponses(ofMillis(1000));
 
         long total = getExecutionTimeOfOperation();
 
-        assertThat(total).isCloseTo(1500L, Offset.offset(20L));
+        assertThat(total).isCloseTo(1000L, Offset.offset(20L));
 
         aerospikeTestOperations.removeNetworkLatencyForResponses();
 

--- a/embedded-couchbase/src/test/java/com/playtika/test/couchbase/DisableCouchbaseTest.java
+++ b/embedded-couchbase/src/test/java/com/playtika/test/couchbase/DisableCouchbaseTest.java
@@ -26,23 +26,34 @@ package com.playtika.test.couchbase;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = DisableCouchbaseTest.TestConfiguration.class,
-        properties = {
-                "embedded.couchbase.enabled=false",
-                "spring.profiles.active=disabled"
-        })
+        properties = "embedded.couchbase.enabled=false")
 public class DisableCouchbaseTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("bucketDependencyPostProcessor", "asyncBucketDependencyPostProcessor", "couchbaseClientDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-couchbase/src/test/java/com/playtika/test/couchbase/EmbeddedCouchbaseBootstrapConfigurationTest.java
+++ b/embedded-couchbase/src/test/java/com/playtika/test/couchbase/EmbeddedCouchbaseBootstrapConfigurationTest.java
@@ -37,8 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = {CouchbaseConfiguration.class, LegacyClientConfiguration.class},
-        properties = {"spring.profiles.active=enabled"}
-)
+        properties = {
+                "spring.profiles.active=enabled",
+                "embedded.couchbase.install.enabled=true"
+        })
 public abstract class EmbeddedCouchbaseBootstrapConfigurationTest {
 
     @Autowired

--- a/embedded-couchbase/src/test/java/com/playtika/test/couchbase/springdata/SpringDataTest.java
+++ b/embedded-couchbase/src/test/java/com/playtika/test/couchbase/springdata/SpringDataTest.java
@@ -68,9 +68,9 @@ public class SpringDataTest extends EmbeddedCouchbaseBootstrapConfigurationTest 
 
     @Test
     public void shouldEmulateNetworkLatency() throws Exception {
-        couchbaseNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        couchbaseNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> documentRepository.findById("abc")))
-                        .isCloseTo(1500L, Offset.offset(100L))
+                        .isCloseTo(1000L, Offset.offset(100L))
         );
 
         assertThat(durationOf(() -> documentRepository.findById("abc")))

--- a/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/DisabledElasticSearchTest.java
+++ b/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/DisabledElasticSearchTest.java
@@ -25,16 +25,30 @@ package com.playtika.test.elasticsearch;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("disabled")
 @SpringBootTest
 public class DisabledElasticSearchTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("elasticClientDependencyPostProcessor");
     }
 }

--- a/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/EmbeddedElasticSearchBootstrapConfigurationTest.java
+++ b/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/EmbeddedElasticSearchBootstrapConfigurationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("enabled")
-@SpringBootTest
+@SpringBootTest(properties = "embedded.elasticsearch.install.enabled=true")
 public abstract class EmbeddedElasticSearchBootstrapConfigurationTest {
 
     @Autowired

--- a/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/springdata/SpringDataTest.java
+++ b/embedded-elasticsearch/src/test/java/com/playtika/test/elasticsearch/springdata/SpringDataTest.java
@@ -64,9 +64,9 @@ public class SpringDataTest extends EmbeddedElasticSearchBootstrapConfigurationT
 
     @Test
     public void shouldEmulateNetworkLatency() throws Exception {
-        elasticSearchNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        elasticSearchNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> documentRepository.findById("abc")))
-                        .isCloseTo(1500L, Offset.offset(100L))
+                        .isCloseTo(1000L, Offset.offset(100L))
         );
 
         assertThat(durationOf(() -> documentRepository.findById("abc")))

--- a/embedded-google-pubsub/src/test/java/com/playtika/test/pubsub/DisablePubsubTest.java
+++ b/embedded-google-pubsub/src/test/java/com/playtika/test/pubsub/DisablePubsubTest.java
@@ -4,11 +4,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,11 +24,23 @@ public class DisablePubsubTest {
     @Autowired
     private ConfigurableEnvironment environment;
 
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
+
     @Test
     public void propertiesAreNotAvailable() {
         assertThat(environment.getProperty("embedded.google.pubsub.port")).isNullOrEmpty();
         assertThat(environment.getProperty("embedded.google.pubsub.host")).isNullOrEmpty();
         assertThat(environment.getProperty("embedded.google.pubsub.project-id")).isNullOrEmpty();
+    }
+
+    @Test
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("pubsubTemplateDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/EmbeddedKafkaTests.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/EmbeddedKafkaTests.java
@@ -70,7 +70,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = EmbeddedKafkaTests.TestConfiguration.class,
-        properties = "embedded.kafka.topicsToCreate=autoCreatedTopic"
+        properties = {
+                "embedded.kafka.topicsToCreate=autoCreatedTopic",
+                "embedded.kafka.install.enabled=true"
+        }
 )
 public class EmbeddedKafkaTests {
 
@@ -110,9 +113,9 @@ public class EmbeddedKafkaTests {
 
     @Test
     public void shouldEmulateLatencyOnSend() throws Exception {
-        kafkaNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        kafkaNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> sendMessage(TOPIC, "abc0")))
-                        .isGreaterThan(1500L)
+                        .isGreaterThan(1000L)
         );
 
         assertThat(durationOf(() -> sendMessage(TOPIC, "abc1")))

--- a/embedded-mariadb/src/test/java/com/playtika/test/mariadb/DisableMariaDBTest.java
+++ b/embedded-mariadb/src/test/java/com/playtika/test/mariadb/DisableMariaDBTest.java
@@ -1,61 +1,62 @@
 /*
-* The MIT License (MIT)
-*
-* Copyright (c) 2018 Playtika
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in all
-* copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE.
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Playtika
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package com.playtika.test.mariadb;
 
-import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
 
-import javax.sql.DataSource;
-
-import static com.playtika.test.mariadb.MariaDBProperties.BEAN_NAME_EMBEDDED_MARIADB;
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Slf4j
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = DisableMariaDBTest.TestConfiguration.class,
-        properties = {
-                  "embedded.mariadb.enabled=false"
-                , "spring.profiles.active=disabled"
-        }
+        properties = "embedded.mariadb.enabled=false"
 )
 public class DisableMariaDBTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("datasourceDependencyPostProcessor");
     }
 
-    @EnableAutoConfiguration
+    @EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class)
     @Configuration
     static class TestConfiguration {
     }

--- a/embedded-mariadb/src/test/java/com/playtika/test/mariadb/EmbeddedMariaDBBootstrapConfigurationTest.java
+++ b/embedded-mariadb/src/test/java/com/playtika/test/mariadb/EmbeddedMariaDBBootstrapConfigurationTest.java
@@ -42,7 +42,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.sql.DataSource;
-
 import java.util.concurrent.Callable;
 
 import static com.playtika.test.mariadb.MariaDBProperties.BEAN_NAME_EMBEDDED_MARIADB;
@@ -53,9 +52,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-        classes = EmbeddedMariaDBBootstrapConfigurationTest.TestConfiguration.class
-        , properties = "spring.profiles.active=enabled"
-)
+        classes = EmbeddedMariaDBBootstrapConfigurationTest.TestConfiguration.class,
+        properties = {
+                "spring.profiles.active=enabled",
+                "embedded.mariadb.install.enabled=true"
+        })
 public class EmbeddedMariaDBBootstrapConfigurationTest {
 
     @Autowired
@@ -88,9 +89,9 @@ public class EmbeddedMariaDBBootstrapConfigurationTest {
         jdbcTemplate.execute("CREATE TABLE operator(id INT, name VARCHAR(64));");
         jdbcTemplate.execute("insert into operator (id, name) values (1, 'test');");
 
-        mariadbNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        mariadbNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> jdbcTemplate.queryForList("select name from operator", String.class)))
-                        .isCloseTo(1500L, Offset.offset(100L))
+                        .isCloseTo(1000L, Offset.offset(100L))
         );
 
         assertThat(durationOf(() -> jdbcTemplate.queryForList("select name from operator", String.class)))

--- a/embedded-mariadb/src/test/resources/application-disabled.properties
+++ b/embedded-mariadb/src/test/resources/application-disabled.properties
@@ -1,4 +1,0 @@
-spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/test
-spring.datasource.username=test
-spring.datasource.password=test

--- a/embedded-memsql/src/test/java/com/playtika/test/memsql/DisableMemSQLTest.java
+++ b/embedded-memsql/src/test/java/com/playtika/test/memsql/DisableMemSQLTest.java
@@ -26,10 +26,16 @@ package com.playtika.test.memsql;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -37,8 +43,16 @@ import org.springframework.test.context.junit4.SpringRunner;
         properties = {"embedded.memsql.enabled=false", "spring.profiles.active=disabled"})
 public class DisableMemSQLTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("datasourceDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-memsql/src/test/java/com/playtika/test/memsql/EmbeddedMemSqlBootstrapConfigurationTest.java
+++ b/embedded-memsql/src/test/java/com/playtika/test/memsql/EmbeddedMemSqlBootstrapConfigurationTest.java
@@ -47,8 +47,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = EmbeddedMemSqlBootstrapConfigurationTest.TestConfiguration.class,
-        properties = {"spring.profiles.active=enabled"}
-)
+        properties = {
+                "spring.profiles.active=enabled",
+                "embedded.memsql.install.enabled=true"
+        })
 public class EmbeddedMemSqlBootstrapConfigurationTest {
 
     @Autowired
@@ -76,9 +78,9 @@ public class EmbeddedMemSqlBootstrapConfigurationTest {
         jdbcTemplate.execute("create table bar (id int primary key);");
         jdbcTemplate.execute("insert into bar values (1), (2), (3);");
 
-        memsqlNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        memsqlNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> jdbcTemplate.queryForList("select * from bar")))
-                        .isGreaterThan(1500L)
+                        .isGreaterThan(1000L)
         );
 
         assertThat(durationOf(() -> jdbcTemplate.queryForList("select * from bar")))

--- a/embedded-minio/src/test/java/com/playtika/test/minio/EmbeddedMinioBootstrapConfigurationTest.java
+++ b/embedded-minio/src/test/java/com/playtika/test/minio/EmbeddedMinioBootstrapConfigurationTest.java
@@ -24,7 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-        classes = EmbeddedMinioBootstrapConfigurationTest.MinioTestConfiguration.class
+        classes = EmbeddedMinioBootstrapConfigurationTest.MinioTestConfiguration.class,
+        properties = "embedded.minio.install.enabled=true"
 )
 public class EmbeddedMinioBootstrapConfigurationTest {
 
@@ -54,9 +55,9 @@ public class EmbeddedMinioBootstrapConfigurationTest {
 
     @Test
     public void shouldEmulateLatency() throws Exception {
-        minioNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        minioNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> writeFileToMinio("example.txt", getFilePath("example.txt"))))
-                        .isCloseTo(1500L, Offset.offset(300L))
+                        .isCloseTo(1000L, Offset.offset(300L))
         );
 
         assertThat(durationOf(() -> writeFileToMinio("example.txt", getFilePath("example.txt"))))

--- a/embedded-mongodb/src/test/java/com/playtika/test/mongodb/DisableMongodbTest.java
+++ b/embedded-mongodb/src/test/java/com/playtika/test/mongodb/DisableMongodbTest.java
@@ -24,7 +24,6 @@
 package com.playtika.test.mongodb;
 
 import com.playtika.test.mongodb.DisableMongodbTest.TestConfiguration;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,17 +37,18 @@ import org.testcontainers.containers.GenericContainer;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@Slf4j
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = TestConfiguration.class,
-        properties = {"embedded.mongodb.enabled=false"})
+        properties = "embedded.mongodb.enabled=false"
+)
 public class DisableMongodbTest {
 
-    @Autowired ConfigurableListableBeanFactory beanFactory;
+    @Autowired
+    private ConfigurableListableBeanFactory beanFactory;
 
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
         String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
         String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
 
@@ -58,5 +58,6 @@ public class DisableMongodbTest {
 
     @EnableAutoConfiguration
     @Configuration
-    static class TestConfiguration {}
+    static class TestConfiguration {
+    }
 }

--- a/embedded-mongodb/src/test/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapConfigurationTest.java
+++ b/embedded-mongodb/src/test/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapConfigurationTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(
         properties = {
-                "embedded.mongodb.enabled=true",
+                "embedded.mongodb.install.enabled=true",
                 "spring.data.mongodb.uri=mongodb://${embedded.mongodb.host}:${embedded.mongodb.port}/${embedded.mongodb.database}"
         })
 public class EmbeddedMongodbBootstrapConfigurationTest {
@@ -72,9 +72,9 @@ public class EmbeddedMongodbBootstrapConfigurationTest {
 
     @Test
     public void shouldEmulateLatency() throws Exception {
-        mongodbNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        mongodbNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> mongoTemplate.findById("any", Foo.class)))
-                        .isCloseTo(1500L, Offset.offset(100L))
+                        .isCloseTo(1000L, Offset.offset(100L))
         );
 
         assertThat(durationOf(() -> mongoTemplate.findById("any", Foo.class)))

--- a/embedded-neo4j/src/test/java/com/playtika/test/neo4j/DisableNeo4jTest.java
+++ b/embedded-neo4j/src/test/java/com/playtika/test/neo4j/DisableNeo4jTest.java
@@ -26,10 +26,16 @@ package com.playtika.test.neo4j;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -37,8 +43,18 @@ import org.springframework.test.context.junit4.SpringRunner;
         properties = "embedded.neo4j.enabled=false")
 public class DisableNeo4jTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain(
+                "neo4jSessionDependencyPostProcessor",
+                "neo4jSessionFactoryDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-neo4j/src/test/java/com/playtika/test/neo4j/EmbeddedNeo4JBootstrapConfigurationTest.java
+++ b/embedded-neo4j/src/test/java/com/playtika/test/neo4j/EmbeddedNeo4JBootstrapConfigurationTest.java
@@ -48,7 +48,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = EmbeddedNeo4JBootstrapConfigurationTest.TestConfiguration.class)
+@SpringBootTest(
+        classes = EmbeddedNeo4JBootstrapConfigurationTest.TestConfiguration.class,
+        properties = "embedded.neo4j.install.enabled=true"
+)
 @ActiveProfiles("enabled")
 public class EmbeddedNeo4JBootstrapConfigurationTest {
 
@@ -103,9 +106,9 @@ public class EmbeddedNeo4JBootstrapConfigurationTest {
 
     @Test
     public void shouldEmulateLatency() throws Exception {
-        neo4jNetworkTestOperations.withNetworkLatency(ofMillis(1500),
+        neo4jNetworkTestOperations.withNetworkLatency(ofMillis(1000),
                 () -> assertThat(durationOf(() -> personRepository.findByName("any")))
-                        .isGreaterThan(1500L)
+                        .isGreaterThan(1000L)
         );
 
         assertThat(durationOf(() -> personRepository.findByName("any")))

--- a/embedded-postgresql/src/test/java/com/playtika/test/postgresql/DisablePostgreSQLTest.java
+++ b/embedded-postgresql/src/test/java/com/playtika/test/postgresql/DisablePostgreSQLTest.java
@@ -23,18 +23,32 @@
  */
 package com.playtika.test.postgresql;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("disabled")
 @SpringBootTest(properties = "embedded.postgresql.enabled=false")
 class DisablePostgreSQLTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    void contextLoad() {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("datasourceDependencyPostProcessor");
     }
 }

--- a/embedded-rabbitmq/src/test/java/com/playtika/test/rabbitmq/DisableRabbitMQTest.java
+++ b/embedded-rabbitmq/src/test/java/com/playtika/test/rabbitmq/DisableRabbitMQTest.java
@@ -27,11 +27,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,7 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DisableRabbitMQTest {
     @Autowired
     private ConfigurableEnvironment environment;
-
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
 
     @Test
     public void propertiesAreNotAvailable() {
@@ -52,6 +56,15 @@ public class DisableRabbitMQTest {
         assertThat(environment.getProperty("embedded.rabbitmq.vhost")).isNullOrEmpty();
         assertThat(environment.getProperty("embedded.rabbitmq.user")).isNullOrEmpty();
         assertThat(environment.getProperty("embedded.rabbitmq.password")).isNullOrEmpty();
+    }
+
+    @Test
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("rabbitMessagingTemplateDependencyPostProcessor");
     }
 
 

--- a/embedded-redis/src/test/java/com/playtika/test/redis/DisableRedisTest.java
+++ b/embedded-redis/src/test/java/com/playtika/test/redis/DisableRedisTest.java
@@ -26,10 +26,16 @@ package com.playtika.test.redis;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -37,8 +43,19 @@ import org.springframework.test.context.junit4.SpringRunner;
         properties = "embedded.redis.enabled=false")
 public class DisableRedisTest {
 
+    @Autowired
+    ConfigurableListableBeanFactory beanFactory;
+
     @Test
-    public void contextLoad() throws Exception {
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain(
+                "redisConnectionFactoryDependencyPostProcessor",
+                "redisTemplateDependencyPostProcessor",
+                "jedisDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/embedded-redis/src/test/java/com/playtika/test/redis/EmbeddedRedisBootstrapConfigurationTest.java
+++ b/embedded-redis/src/test/java/com/playtika/test/redis/EmbeddedRedisBootstrapConfigurationTest.java
@@ -49,7 +49,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = EmbeddedRedisBootstrapConfigurationTest.TestConfiguration.class)
+@SpringBootTest(
+        classes = EmbeddedRedisBootstrapConfigurationTest.TestConfiguration.class,
+        properties = "embedded.redis.install.enabled=true"
+)
 @ActiveProfiles("enabled")
 public class EmbeddedRedisBootstrapConfigurationTest {
 

--- a/embedded-voltdb/src/test/java/com/playtika/test/voltdb/DisableVoltDBTest.java
+++ b/embedded-voltdb/src/test/java/com/playtika/test/voltdb/DisableVoltDBTest.java
@@ -27,12 +27,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.testcontainers.containers.GenericContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,11 +46,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DisableVoltDBTest {
 
     @Autowired
-    private Environment environment;
+    ConfigurableListableBeanFactory beanFactory;
 
     @Test
-    public void voltDBDoesNotStart() {
-        assertThat(environment.getProperty("embedded.voltdb.host")).isNull();
+    public void contextLoads() {
+        String[] containers = beanFactory.getBeanNamesForType(GenericContainer.class);
+        String[] postProcessors = beanFactory.getBeanNamesForType(BeanFactoryPostProcessor.class);
+
+        assertThat(containers).isEmpty();
+        assertThat(postProcessors).doesNotContain("datasourceDependencyPostProcessor");
     }
 
     @EnableAutoConfiguration

--- a/testcontainers-common/src/main/java/com/playtika/test/common/properties/InstallPackageProperties.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/properties/InstallPackageProperties.java
@@ -8,6 +8,6 @@ import java.util.Set;
 @Data
 public class InstallPackageProperties {
 
-    boolean enabled = true;
+    boolean enabled = false;
     Set<String> packages = new HashSet<>();
 }


### PR DESCRIPTION
Disable package installation for all containers by default as it increases startup time even if you do not use features that require packages to be installed.

You should specify property explicitly: embedded.name-of-container.install.enabled=true for the packages to be installed.