### PR TITLE
FEATURE #213 : add posibility to disable filesystem binding in containers for kafka and zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ embedded.kafka.topicsToCreate=some_topic
   * To use another kafka version pick corresponding docker image on  [dockerhub](https://hub.docker.com/r/confluentinc/cp-kafka/tags)
   * [Confluent Platform and Apache Kafka Compatibility](https://docs.confluent.io/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility)
 * embedded.kafka.waitTimeoutInSeconds `(default is 60 seconds)`
+
+##### Filesystem bindings
+Containers for `embedded-kafka` and `embedded-zookeper` bind their volumes to host filesystem. By default, to your projects `target` folder. You can configure binding using properties:
+* embedded.zookeeper.fileSystemBind.enabled `(true|false, default is 'true')`
+* embedded.zookeeper.fileSystemBind.dataFolder `(default : target/embedded-zk-data)`
+* embedded.zookeeper.fileSystemBind.txnLogsFolder `(default : target/embedded-zk-txn-logs)`
+* embedded.kafka.enabled `(true|false, default is 'true')`
+* embedded.kafka.fileSystemBind.dataFolder `(default : target/embedded-kafka-data)`
+
 ##### Produces
 * embedded.zookeeper.zookeeperConnect
 * embedded.kafka.brokerList

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/KafkaConfigurationProperties.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/KafkaConfigurationProperties.java
@@ -44,17 +44,18 @@ public class KafkaConfigurationProperties extends CommonContainerProperties {
     protected String containerBrokerList;
     protected int brokerPort = 0;
     protected int containerBrokerPort = 0;
-    int socketTimeoutMs = 5_000;
-    int bufferSize = 64 * 1024;
-    String dataFileSystemBind = "target/embedded-kafka-data";
-    String dockerImage = "confluentinc/cp-kafka:5.4.1";
-    Collection<String> topicsToCreate = Collections.emptyList();
-    transient final int replicationFactor = 1;
+    protected int socketTimeoutMs = 5_000;
+    protected int bufferSize = 64 * 1024;
+    protected String dockerImage = "confluentinc/cp-kafka:5.4.1";
+    protected Collection<String> topicsToCreate = Collections.emptyList();
+    protected transient final int replicationFactor = 1;
     //https://github.com/kafka-dev/kafka/blob/0.6.1/core/src/test/scala/unit/kafka/utils/TestUtils.scala#L114
-    transient final int logFlushIntervalMs = 1;
+    protected transient final int logFlushIntervalMs = 1;
     //https://github.com/spring-projects/spring-kafka/blob/v1.3.5.RELEASE/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java#L193
-    transient final int replicaSocketTimeoutMs = 1000;
-    transient final int controllerSocketTimeoutMs = 1000;
+    protected transient final int replicaSocketTimeoutMs = 1000;
+    protected transient final int controllerSocketTimeoutMs = 1000;
+
+    protected FileSystemBind fileSystemBind = new FileSystemBind();
 
     /**
      * Kafka container port will be assigned automatically if free port is available.
@@ -71,4 +72,9 @@ public class KafkaConfigurationProperties extends CommonContainerProperties {
         }
     }
 
+    @Data
+    public static final class FileSystemBind {
+        private boolean enabled = true;
+        private String dataFolder = "target/embedded-kafka-data";
+    }
 }

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/ZookeeperConfigurationProperties.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/ZookeeperConfigurationProperties.java
@@ -38,14 +38,13 @@ public class ZookeeperConfigurationProperties extends CommonContainerProperties 
 
     public static final String ZOOKEEPER_BEAN_NAME = "zookeeper";
 
-    String zookeeperConnect;
+    protected String zookeeperConnect;
     protected String containerZookeeperConnect;
-    int zookeeperPort = 0;
-    int sessionTimeoutMs = 5_000;
-    int socketTimeoutMs = 5_000;
-    String dataFileSystemBind = "target/embedded-zk-data";
-    String txnLogsFileSystemBind = "target/embedded-zk-txn-logs";
-    String dockerImage = "confluentinc/cp-zookeeper:5.4.1";
+    protected int zookeeperPort = 0;
+    protected int sessionTimeoutMs = 5_000;
+    protected int socketTimeoutMs = 5_000;
+    protected String dockerImage = "confluentinc/cp-zookeeper:5.4.1";
+    protected FileSystemBind fileSystemBind = new FileSystemBind();
 
     /**
      * Zookeeper container port will be assigned automatically if free port is available.
@@ -56,5 +55,12 @@ public class ZookeeperConfigurationProperties extends CommonContainerProperties 
         if (this.zookeeperPort == 0) {
             this.zookeeperPort = ContainerUtils.getAvailableMappingPort();
         }
+    }
+
+    @Data
+    public static final class FileSystemBind {
+        private boolean enabled = true;
+        private String dataFolder = "target/embedded-zk-data";
+        private String txnLogsFolder = "target/embedded-zk-txn-logs";
     }
 }

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/AbstractEmbeddedKafkaTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/AbstractEmbeddedKafkaTest.java
@@ -1,0 +1,132 @@
+package com.playtika.test.kafka;
+
+import com.playtika.test.common.utils.ThrowingRunnable;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.assertj.core.util.Lists;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BATCH_SIZE_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class AbstractEmbeddedKafkaTest {
+    protected AdminClient adminClient;
+    protected List<String> kafkaBrokerList;
+
+    public void setAdminClient(AdminClient adminClient) {
+        this.adminClient = adminClient;
+    }
+
+    public void setKafkaBrokerList(List<String> kafkaBrokerList) {
+        this.kafkaBrokerList = kafkaBrokerList;
+    }
+
+    protected void assertThatTopicExists(String topicName) throws Exception {
+        ListTopicsResult result = adminClient.listTopics();
+        Set<String> topics = result.names().get(10, TimeUnit.SECONDS);
+        assertThat(topics).contains(topicName);
+    }
+
+    protected void sendMessage(String topic, String message) throws Exception {
+        try (KafkaProducer<String, String> kafkaProducer = createProducer()) {
+            kafkaProducer.send(new ProducerRecord<>(topic, message)).get();
+        }
+    }
+
+    protected String consumeMessage(String topic) {
+        return consumeMessages(topic)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("no message received"));
+    }
+
+    protected List<String> consumeMessages(String topic) {
+        try (KafkaConsumer<String, String> consumer = createConsumer(topic)) {
+            return pollForRecords(consumer)
+                    .stream()
+                    .map(ConsumerRecord::value)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    protected KafkaProducer<String, String> createProducer() {
+        Map<String, Object> producerConfiguration = getKafkaProducerConfiguration();
+        return new KafkaProducer<>(producerConfiguration);
+    }
+
+    protected KafkaConsumer<String, String> createConsumer(String topic) {
+        Map<String, Object> consumerConfiguration = getKafkaConsumerConfiguration();
+        Properties properties = new Properties();
+        properties.putAll(consumerConfiguration);
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
+        consumer.subscribe(singleton(topic));
+        return consumer;
+    }
+
+    protected static <K, V> List<ConsumerRecord<K, V>> pollForRecords(KafkaConsumer<K, V> consumer) {
+        ConsumerRecords<K, V> received = consumer.poll(Duration.ofSeconds(10));
+        return received == null ? emptyList() : Lists.newArrayList(received);
+    }
+
+    protected Map<String, Object> getKafkaProducerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BOOTSTRAP_SERVERS_CONFIG, kafkaBrokerList);
+        configs.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(RETRIES_CONFIG, 0);
+        configs.put(BATCH_SIZE_CONFIG, 0);
+        return configs;
+    }
+
+    protected Map<String, Object> getKafkaConsumerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(BOOTSTRAP_SERVERS_CONFIG, kafkaBrokerList);
+        configs.put(GROUP_ID_CONFIG, "testGroup");
+        configs.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        return configs;
+    }
+
+    protected static long durationOf(ThrowingRunnable operation) throws Exception {
+        long startTimestamp = System.currentTimeMillis();
+        operation.run();
+        return System.currentTimeMillis() - startTimestamp;
+    }
+
+    protected static Path projectDir() {
+        String classesPath = AbstractEmbeddedKafkaTest.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .getPath();
+        return Paths.get(classesPath).getParent().getParent();
+    }
+}

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/BaseEmbeddedKafkaTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/BaseEmbeddedKafkaTest.java
@@ -1,0 +1,104 @@
+package com.playtika.test.kafka;
+
+import com.playtika.test.common.operations.NetworkTestOperations;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static java.time.Duration.ofMillis;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class BaseEmbeddedKafkaTest extends AbstractEmbeddedKafkaTest {
+    private static final String TOPIC = "topic1";
+    private static final String MESSAGE = "test message";
+
+    protected KafkaTopicsConfigurer kafkaTopicsConfigurer;
+    protected NetworkTestOperations kafkaNetworkTestOperations;
+
+    @Autowired
+    @Override
+    public void setAdminClient(AdminClient adminClient) {
+        super.setAdminClient(adminClient);
+    }
+
+    @Autowired
+    @Override
+    public void setKafkaBrokerList(@Value("${embedded.kafka.brokerList}") List<String> kafkaBrokerList) {
+        super.setKafkaBrokerList(kafkaBrokerList);
+    }
+
+    @Autowired
+    public void setKafkaTopicsConfigurer(KafkaTopicsConfigurer kafkaTopicsConfigurer) {
+        this.kafkaTopicsConfigurer = kafkaTopicsConfigurer;
+    }
+
+    @Autowired
+    public void setKafkaNetworkTestOperations(NetworkTestOperations kafkaNetworkTestOperations) {
+        this.kafkaNetworkTestOperations = kafkaNetworkTestOperations;
+    }
+
+    @Test
+    @DisplayName("creates topics on startup")
+    public void shouldAutoCreateTopic() throws Exception {
+        assertThatTopicExists("autoCreatedTopic");
+    }
+
+    @Test
+    @DisplayName("allows to create other topics")
+    public void shouldCreateTopic() throws Exception {
+        String topicToCreate = "topicToCreate";
+
+        kafkaTopicsConfigurer.createTopics(Collections.singletonList(topicToCreate));
+
+        assertThatTopicExists(topicToCreate);
+    }
+
+    @Test
+    @DisplayName("allows send and consume messages")
+    public void shouldSendAndConsumeMessage() throws Exception {
+        sendMessage(TOPIC, MESSAGE);
+
+        String consumedMessage = consumeMessage(TOPIC);
+
+        assertThat(consumedMessage)
+                .isEqualTo(MESSAGE);
+    }
+
+    @Test
+    @DisplayName("allows to emulate latency on send")
+    public void shouldEmulateLatencyOnSend() throws Exception {
+        kafkaNetworkTestOperations
+                .withNetworkLatency(
+                        ofMillis(1000),
+                        () -> assertThat(durationOf(() -> sendMessage(TOPIC, "abc0")))
+                                .isGreaterThan(1000L));
+
+        assertThat(durationOf(() -> sendMessage(TOPIC, "abc1")))
+                .isLessThan(200L);
+
+        assertThat(consumeMessages(TOPIC))
+                .containsExactly("abc0", "abc1");
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class TestConfiguration {
+
+        @Bean
+        AdminClient adminClient(@Value("${embedded.kafka.brokerList}") String brokers) {
+            Properties config = new Properties();
+            config.put(BOOTSTRAP_SERVERS_CONFIG, brokers);
+            return AdminClient.create(config);
+        }
+    }
+}

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/EmbeddedKafkaWithoutBindingTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/EmbeddedKafkaWithoutBindingTest.java
@@ -1,0 +1,50 @@
+package com.playtika.test.kafka;
+
+import com.playtika.test.kafka.properties.KafkaConfigurationProperties;
+import com.playtika.test.kafka.properties.ZookeeperConfigurationProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        properties = {
+                "embedded.zookeeper.fileSystemBind.enabled=false",
+                "embedded.zookeeper.fileSystemBind.dataFolder=target/embedded-zk-data-without-binding",
+                "embedded.zookeeper.fileSystemBind.txnLogsFolder=target/embedded-zk-txn-logs-without-binding",
+
+                "embedded.kafka.topicsToCreate=autoCreatedTopic",
+                "embedded.kafka.fileSystemBind.enabled=false",
+                "embedded.kafka.fileSystemBind.dataFolder=target/embedded-kafka-data-without-binding"
+        },
+        classes = BaseEmbeddedKafkaTest.TestConfiguration.class
+)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Test that embedded-kafka without filesystem binding")
+public class EmbeddedKafkaWithoutBindingTest extends BaseEmbeddedKafkaTest {
+    @Autowired
+    private ZookeeperConfigurationProperties zookeeperProperties;
+
+    @Autowired
+    private KafkaConfigurationProperties kafkaProperties;
+
+    @AfterAll
+    public void shouldBindToFileSystem() {
+        Path projectDir = projectDir();
+        Path zookeeperDataFolder = projectDir.resolve(zookeeperProperties.getFileSystemBind().getDataFolder());
+        Path zookeeperTxnLogsFolder = projectDir.resolve(zookeeperProperties.getFileSystemBind().getTxnLogsFolder());
+        Path kafkaDataFolder = projectDir.resolve(kafkaProperties.getFileSystemBind().getDataFolder());
+
+        assertThat(zookeeperDataFolder.toFile())
+                .doesNotExist();
+        assertThat(zookeeperTxnLogsFolder.toFile())
+                .doesNotExist();
+        assertThat(kafkaDataFolder.toFile())
+                .doesNotExist();
+    }
+}


### PR DESCRIPTION
Related to issue #213

The problem is that during execution of integration tests with kafka, three folders are created inside `target` dir by kafka and zookeeper containers: `embedded-kafka-data`, `embedded-zk-data` & `embedded-zk-txn-logs`. All three are owned by root because process in docker is run as root.

It seems, that test-containers as present moment does not support `--userns-remap` to make it possible map user inside docker container (see issues: https://github.com/testcontainers/testcontainers-java/issues/712 and https://github.com/testcontainers/testcontainers-java/issues/700).

So I found a work around. As I don't really need mapping of volumes from containers during integration tests, I changed configuration to make it possible disable fileSystemBind from containers zookeeper & kafka (only those two are using binding):

```
embedded.zookeeper.fileSystemBind.enabled=false
embedded.zookeeper.fileSystemBind.dataFolder=target/embedded-zk-data
embedded.zookeeper.fileSystemBind.txnLogsFolder=target/embedded-zk-txn-logs

embedded.kafka.fileSystemBind.enabled=false
embedded.kafka.fileSystemBind.dataFolder=target/embedded-kafka-data
```