### PR TITLE
REFACTOR: migrate module embedded-kafka on Junit5

### DIFF
--- a/embedded-kafka/pom.xml
+++ b/embedded-kafka/pom.xml
@@ -62,10 +62,5 @@
             <artifactId>camel-kafka</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-test-spring</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/DisableKafkaTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/DisableKafkaTest.java
@@ -26,14 +26,15 @@ package com.playtika.test.kafka;
 import com.playtika.test.kafka.configuration.EmbeddedKafkaBootstrapConfiguration;
 import com.playtika.test.kafka.configuration.EmbeddedKafkaTestOperationsAutoConfiguration;
 import com.playtika.test.kafka.configuration.camel.EmbeddedKafkaCamelAutoConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisplayName("Test that application")
 public class DisableKafkaTest {
-
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(
                     EmbeddedKafkaBootstrapConfiguration.class,
@@ -41,8 +42,9 @@ public class DisableKafkaTest {
                     EmbeddedKafkaCamelAutoConfiguration.class));
 
     @Test
+    @DisplayName("run with zookeeper & kafka disabled")
     public void contextLoads() {
-        this.contextRunner
+        contextRunner
                 .withPropertyValues(
                         "embedded.kafka.enabled=false",
                         "embedded.zookeeper.enabled=false")
@@ -52,5 +54,4 @@ public class DisableKafkaTest {
                         .doesNotHaveBean("zookeeper")
                         .doesNotHaveBean("kafka"));
     }
-
 }

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/properties/KafkaConfigurationPropertiesTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/properties/KafkaConfigurationPropertiesTest.java
@@ -24,16 +24,20 @@
 package com.playtika.test.kafka.properties;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static nl.jqno.equalsverifier.Warning.NONFINAL_FIELDS;
 import static nl.jqno.equalsverifier.Warning.STRICT_INHERITANCE;
 
+@DisplayName("Test that KafkaConfigurationProperties")
 public class KafkaConfigurationPropertiesTest {
 
     @Test
-    public void shouldHave_equalsAndHashcodeContract() {
-        EqualsVerifier.forClass(KafkaConfigurationProperties.class)
+    @DisplayName("respects contract for equals & hashCode")
+    public void shouldRespectEqualsAndHashcodeContract() {
+        EqualsVerifier
+                .forClass(KafkaConfigurationProperties.class)
                 .suppress(NONFINAL_FIELDS, STRICT_INHERITANCE)
                 .withRedefinedSuperclass()
                 .verify();

--- a/embedded-kafka/src/test/java/com/playtika/test/kafka/properties/ZookeeperConfigurationPropertiesTest.java
+++ b/embedded-kafka/src/test/java/com/playtika/test/kafka/properties/ZookeeperConfigurationPropertiesTest.java
@@ -24,16 +24,20 @@
 package com.playtika.test.kafka.properties;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static nl.jqno.equalsverifier.Warning.NONFINAL_FIELDS;
 import static nl.jqno.equalsverifier.Warning.STRICT_INHERITANCE;
 
+@DisplayName("Test that ZookeeperConfigurationProperties")
 public class ZookeeperConfigurationPropertiesTest {
 
     @Test
-    public void shouldHave_equalsAndHashcodeContract() {
-        EqualsVerifier.forClass(ZookeeperConfigurationProperties.class)
+    @DisplayName("respects contract for equals & hashCode")
+    public void shouldRespectEqualsAndHashcodeContract() {
+        EqualsVerifier
+                .forClass(ZookeeperConfigurationProperties.class)
                 .suppress(NONFINAL_FIELDS, STRICT_INHERITANCE)
                 .withRedefinedSuperclass()
                 .verify();


### PR DESCRIPTION
Hello. I noticed you are using Junit4 together with Junit5. So I presume you are progressively migration your tests to Junit5. Here a modest help of mine. I migrated all tests of module embedded-kafka on Junit5.