### PR TITLE
Allow to enable authentication on mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,11 +435,15 @@ VoltDB container has no security enabled, you can use any credentials.
   * You can pick wanted version on [dockerhub](https://hub.docker.com/_/mongo?tab=tags)
 * embedded.mongodb.host `(default is localhost)`
 * embedded.mongodb.port `(default is 27017)`
+* embedded.mongodb.username
+* embedded.mongodb.password
 * embedded.mongodb.database `(default is test)`
 
 ##### Produces
 * embedded.mongodb.host
 * embedded.mongodb.port `(mapped port)`
+* embedded.mongodb.username
+* embedded.mongodb.password
 * embedded.mongodb.database
 
 ##### Example

--- a/embedded-mongodb/src/main/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapConfiguration.java
+++ b/embedded-mongodb/src/main/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapConfiguration.java
@@ -35,6 +35,8 @@ public class EmbeddedMongodbBootstrapConfiguration {
             MongodbStatusCheck mongodbStatusCheck) {
         GenericContainer mongodb =
                 new GenericContainer<>(properties.getDockerImage())
+                        .withEnv("MONGO_INITDB_ROOT_USERNAME", properties.getUsername())
+                        .withEnv("MONGO_INITDB_ROOT_PASSWORD", properties.getPassword())
                         .withEnv("MONGO_INITDB_DATABASE", properties.getDatabase())
                         .withLogConsumer(containerLogsConsumer(log))
                         .withExposedPorts(properties.getPort())
@@ -60,6 +62,8 @@ public class EmbeddedMongodbBootstrapConfiguration {
         LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         map.put("embedded.mongodb.port", mappedPort);
         map.put("embedded.mongodb.host", host);
+        map.compute("embedded.mongodb.username", (k, v) -> properties.getUsername());
+        map.compute("embedded.mongodb.password", (k, v) -> properties.getPassword());
         map.put("embedded.mongodb.database", properties.getDatabase());
 
         log.info("Started mongodb. Connection Details: {}, Connection URI: mongodb://{}:{}/{}", map, host, mappedPort, properties.getDatabase());

--- a/embedded-mongodb/src/main/java/com/playtika/test/mongodb/MongodbProperties.java
+++ b/embedded-mongodb/src/main/java/com/playtika/test/mongodb/MongodbProperties.java
@@ -15,6 +15,8 @@ public class MongodbProperties extends CommonContainerProperties {
     private String dockerImage = "mongo:4.2.0-bionic";
     private String host = "localhost";
     private int port = 27017;
+    private String username;
+    private String password;
     private String database = "test";
 
 }

--- a/embedded-mongodb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-mongodb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -25,6 +25,14 @@
       "name": "embedded.mongodb.database",
       "type": "java.lang.String",
       "defaultValue": "test"
+    },
+    {
+      "name": "embedded.mongodb.username",
+      "type": "java.lang.String"
+    },
+    {
+      "name": "embedded.mongodb.password",
+      "type": "java.lang.String"
     }
   ]
 }

--- a/embedded-mongodb/src/test/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapAuthConfigurationTest.java
+++ b/embedded-mongodb/src/test/java/com/playtika/test/mongodb/EmbeddedMongodbBootstrapAuthConfigurationTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Playtika
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.playtika.test.mongodb;
+
+
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {
+                "embedded.mongodb.install.enabled=true",
+                "embedded.mongodb.username=root",
+                "embedded.mongodb.password=letmein",
+                "spring.data.mongodb.host=${embedded.mongodb.host}",
+                "spring.data.mongodb.port=${embedded.mongodb.port}",
+                "spring.data.mongodb.username=${embedded.mongodb.username}",
+                "spring.data.mongodb.password=${embedded.mongodb.password}",
+                "spring.data.mongodb.database=${embedded.mongodb.database}",
+                "spring.data.mongodb.authentication-database=admin"
+        })
+public class EmbeddedMongodbBootstrapAuthConfigurationTest {
+
+    @Autowired
+    MongoTemplate mongoTemplate;
+
+    @Autowired
+    ConfigurableEnvironment environment;
+
+    @Test
+    public void shouldSaveAndGet() {
+        String someId = UUID.randomUUID().toString();
+        Foo foo = new Foo(someId, "foo", Instant.parse("2019-09-26T07:57:12.801Z"), -42L);
+        mongoTemplate.save(foo);
+
+        assertThat(mongoTemplate.findById(someId, Foo.class)).isEqualTo(foo);
+    }
+
+    @Test
+    public void propertiesAreAvailable() {
+        assertThat(environment.getProperty("embedded.mongodb.port")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.mongodb.host")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.mongodb.username")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.mongodb.password")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.mongodb.database")).isNotEmpty();
+    }
+
+    @Value
+    static class Foo {
+        @Id
+        String someId;
+        String someString;
+        Instant someTimestamp;
+        Long someNumber;
+    }
+}


### PR DESCRIPTION
When setting both `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD`  MongoDB will start with authentication enabled and will create a user with the role `root` in the `admin` authentication database