### PR TITLE
Introduced property to inject the exposed properties as sys properties

### DIFF
--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
@@ -88,12 +88,13 @@ public class EmbeddedPostgreSQLBootstrapConfiguration {
             map.entrySet().forEach( p -> {
                 String key = p.getKey().toUpperCase().replace(".","_");
                 String value = p.getValue() != null ? p.getValue().toString(): null;
-                if(System.getProperty(key) != null) {
-                    if(!System.getProperty(key).equals(value)) {
-                        log.info("The property {} value will be changed from {} to {}", key, System.getProperty(key), value);
+                if(value != null) {
+                    String existingValue = System.getProperty(key);
+                    if (existingValue != null && !existingValue.equals(value)) {
+                        log.info("The property {} value will be changed from {} to {}", key, existingValue, value);
                     }
+                    System.setProperty(key, value);
                 }
-                System.setProperty(key, value);
             });
         }
     }

--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
@@ -82,6 +82,20 @@ public class EmbeddedPostgreSQLBootstrapConfiguration {
 
         MapPropertySource propertySource = new MapPropertySource("embeddedPostgreInfo", map);
         environment.getPropertySources().addFirst(propertySource);
+
+        if(properties.getExposePropsAsSysProps()) {
+            log.info("Exposing properties (additionally) as system properties");
+            map.entrySet().forEach( p -> {
+                String key = p.getKey().toUpperCase().replace(".","_");
+                String value = p.getValue() != null ? p.getValue().toString(): null;
+                if(System.getProperty(key) != null) {
+                    if(!System.getProperty(key).equals(value)) {
+                        log.info("The property {} value will be changed from {} to {}", key, System.getProperty(key), value);
+                    }
+                }
+                System.setProperty(key, value);
+            });
+        }
     }
 
     private static class ConcretePostgreSQLContainer extends PostgreSQLContainer<ConcretePostgreSQLContainer> {

--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class PostgreSQLProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_POSTGRESQL = "embeddedPostgreSql";
     String dockerImage = "postgres:10-alpine";
+    Boolean exposePropsAsSysProps = Boolean.FALSE;
 
     String user = "postgresql";
     String password = "letmein";

--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
@@ -34,7 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class PostgreSQLProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_POSTGRESQL = "embeddedPostgreSql";
     String dockerImage = "postgres:10-alpine";
-    Boolean exposePropsAsSysProps = Boolean.FALSE;
+    public Boolean exposePropsAsSysProps = Boolean.FALSE;
 
     String user = "postgresql";
     String password = "letmein";

--- a/embedded-postgresql/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-postgresql/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,11 @@
       "name": "embedded.postgresql.docker-image",
       "type": "java.lang.String",
       "defaultValue": "postgres:10-alpine"
+    },
+    {
+      "name": "embedded.postgresql.expose-props-as-sys-props",
+      "type": "java.lang.Boolean",
+      "defaultValue": "false"
     }
   ],
   "hints": [
@@ -53,6 +58,19 @@
         {
           "value": "timescale/timescaledb:latest-pg11",
           "description": "Latest 11.x alpine timescaledb version. Ref https://hub.docker.com/r/timescale/timescaledb for further info."
+        }
+      ]
+    },
+    {
+      "name": "embedded.postgresql.expose-props-as-sys-props",
+      "values": [
+        {
+          "value": "true",
+          "description": "Exposes the embedded.postgresql.* properties as system properties. Each property name will be transformed to upper case and the '.' replaced with '_'."
+        },
+        {
+          "value": "false",
+          "description": "Will not Exposed the properties (embedded.postgresql.*) as system properties."
         }
       ]
     }

--- a/embedded-postgresql/src/test/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfigurationSysPropTest.java
+++ b/embedded-postgresql/src/test/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfigurationSysPropTest.java
@@ -1,0 +1,44 @@
+package com.playtika.test.postgresql;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("enabled")
+@SpringBootTest(properties = {"embedded.postgresql.expose-props-as-sys-props=true"})
+class EmbeddedPostgreSQLBootstrapConfigurationSysPropTest {
+
+    @Autowired
+    private ConfigurableEnvironment environment;
+
+    @Test
+    void propertiesAreExposedAsSystemProperties() {
+
+        assertThat(environment.getProperty("embedded.postgresql.host")).isNotEmpty();
+        assertThat(toSysProp("embedded.postgresql.host")).isEqualTo(environment.getProperty("embedded.postgresql.host"));
+
+        assertThat(environment.getProperty("embedded.postgresql.schema")).isNotEmpty();
+        assertThat(toSysProp("embedded.postgresql.schema")).isEqualTo(environment.getProperty("embedded.postgresql.schema"));
+
+        assertThat(environment.getProperty("embedded.postgresql.user")).isNotEmpty();
+        assertThat(toSysProp("embedded.postgresql.user")).isEqualTo(environment.getProperty("embedded.postgresql.user"));
+
+        assertThat(environment.getProperty("embedded.postgresql.password")).isNotEmpty();
+        assertThat(toSysProp("embedded.postgresql.password")).isEqualTo(environment.getProperty("embedded.postgresql.password"));
+
+        assertThat(environment.getProperty("embedded.postgresql.port")).isNotEmpty();
+        assertThat(toSysProp("embedded.postgresql.port")).isEqualTo(environment.getProperty("embedded.postgresql.port"));
+    }
+
+    private String toSysProp(String key) {
+        return (String) environment.getSystemProperties().get(key.toUpperCase().replace(".", "_"));
+    }
+
+}


### PR DESCRIPTION
I am working on getting this project to work with Grails 4. (which is built on top of SpringBoot)

I have had problems with accessing the properties that get created by the embeddedPostgreSql Bean and injecting them into the grails-app/config/application.yml.

These properties seem to be scoped with a bootstrap context that does not get propagate to up to a context where the grails wrapping code can pick them up. (could be a problem with me or a problem with grails implementation) 

I know that one can make use of system properties within application.yml files and so I decided to try that and it works. 
The changes I have made involve creating a property (disabled by default) to allow the integrating party to expose the properties as system properties (transformed to uppercase and replaced '.' with '_', grails/micronaut wants them this way)
    