### PR TITLE
Set aws api keys to systems properties

### DIFF
--- a/embedded-localstack/src/main/java/com/playtika/test/localstack/EmbeddedLocalStackBootstrapConfiguration.java
+++ b/embedded-localstack/src/main/java/com/playtika/test/localstack/EmbeddedLocalStackBootstrapConfiguration.java
@@ -63,6 +63,12 @@ public class EmbeddedLocalStackBootstrapConfiguration {
 
         MapPropertySource propertySource = new MapPropertySource("embeddedLocalstackInfo", map);
         environment.getPropertySources().addFirst(propertySource);
+        setSystemProperties(localStack);
+    }
+
+    private static void setSystemProperties(EmbeddedLocalStackContainer localStack) {
+        System.setProperty("aws.accessKeyId",localStack.getAccessKey());
+        System.setProperty("aws.secretKey",localStack.getAccessKey());
     }
 
     private static class EmbeddedLocalStackContainer extends LocalStackContainer {


### PR DESCRIPTION
The default AWS configuration requires a basic pair of keys at system properties. Therefore normally tests will unless engineer provides them. So the proposal is to automate the process for tests
```
com.amazonaws.services.s3.model.AmazonS3Exception: Forbidden (Service: Amazon S3; Status Code: 403; Error Code: 403 Forbidden; Request ID: null; S3 Extended Request ID: null)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1660)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1324)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1074)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:745)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:719)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:701)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:669)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:651)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:515)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4443)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4390)
	at com.amazonaws.services.s3.AmazonS3Client.deleteObject(AmazonS3Client.java:2123)
	at com.amazonaws.services.s3.AmazonS3Client.deleteObject(AmazonS3Client.java:2108)
```