### PR TITLE
Add note about the difference between embedded.kafka/containes.enabled 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,8 @@ embedded.containers.enabled=true //default is true
 ----
 NOTE: If you setup, for example  embedded.kafka.enabled + embedded.containers.enabled, result will be same as using AND between two booleans.
 
+NOTE: embedded.kafka.enabled=false will cause DockerNotPresentException if you don't have docker installed. But embedded.containers.enabled=false won't cause any exceptions in this case.
+
 |===
 |Setting1 |Setting2 |Outcome
 


### PR DESCRIPTION
It was confusing to have an issue #421 
I noted the difference between  embedded.containes.enabled=false and  embedded.kafka.enabled=false in Readme. 